### PR TITLE
Fixing Wizard hints

### DIFF
--- a/Edubot.HintServer.Server/hint_server/hints.py
+++ b/Edubot.HintServer.Server/hint_server/hints.py
@@ -70,6 +70,13 @@ def generateWizardHints(enumValues: Optional[dict[str, list[str]]], notRelevantF
 
         fieldValues = sorted(
             fieldObj, key=lambda fieldValue: fieldObj[fieldValue]["count"], reverse=True)
+
+        # remove empty values
+        fieldValues = [fieldValue for fieldValue in fieldValues if fieldValue]
+        # skip if we have nothing left, or the only value is set for *all* results, so it doesn't help disambiguate
+        if not fieldValues or len(fieldValues) == 1 and fieldObj[fieldValues[0]]["count"] == totalFound:
+            continue
+
         candidates.append((field, fieldValues, score))
 
     candidates = sorted(candidates, key=lambda item: item[2])


### PR DESCRIPTION
Do not add empty facet values to wizard, do not add facet if no non-empty values are present or the same single value is present for all results.